### PR TITLE
preserve userConfig routePatterns to avoid /** matches unexpected pages

### DIFF
--- a/src/serverApp.ts
+++ b/src/serverApp.ts
@@ -40,7 +40,7 @@ export async function serverApp(dir = 'docs', commandOptions: CommandOptions = {
 
   // set default routePatterns
   if (Array.isArray(userConfig.routePatterns))
-    userConfig.routePatterns = ['/**', '!/404.html', ...userConfig.routePatterns]
+    userConfig.routePatterns = userConfig.routePatterns
   else
     userConfig.routePatterns = ['/**', '!/404.html']
 


### PR DESCRIPTION
The case is my document has lots of `md` files, not all of them are showing in sidebar, i expect to only generate pdf that matches routePatterns, but due to `/**`, all pages being generated.